### PR TITLE
Remove Google Analytics tracking

### DIFF
--- a/hl7-message-analyzer.html
+++ b/hl7-message-analyzer.html
@@ -195,14 +195,6 @@
         }
     </style>
 
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RC1SH0ZHJC"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-        gtag('config', 'G-RC1SH0ZHJC');
-    </script>
 </head>
 <body>
     <header class="header">


### PR DESCRIPTION
## Summary
- remove Google Analytics tracking snippet from `hl7-message-analyzer.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a6326f88332abee9d94163e71f4