### PR TITLE
Add security rel attributes to external links

### DIFF
--- a/hl7-message-analyzer.html
+++ b/hl7-message-analyzer.html
@@ -228,7 +228,7 @@
             <p>Use this tool to parse and understand HL7 v2.x messages. It highlights segments, fields, and components, offers a search feature to locate segments, and provides an ASCII view for deeper inspection. Your data is processed locally for maximum privacy.</p>
             <p>
                 This tool is free and open source. Contribute or review the code on 
-                <a href="https://github.com/josephbartlett/hl7-message-analyzer" target="_blank" rel="noopener">
+                <a href="https://github.com/josephbartlett/hl7-message-analyzer" target="_blank" rel="noopener noreferrer">
                     <i class="fab fa-github"></i> GitHub
                 </a>.
             </p>
@@ -276,16 +276,16 @@
             <h5>Additional Resources</h5>
             <p>For more information on HL7 standards and related materials:</p>
             <ul>
-                <li><a href="http://www.hl7.org/" target="_blank" rel="noopener">HL7 International Official Website</a></li>
-                <li><a href="https://www.hl7.org/implement/standards/index.cfm" target="_blank" rel="noopener">HL7 Standards & Implementations</a></li>
-                <li><a href="https://www.hl7.org/fhir/" target="_blank" rel="noopener">HL7 FHIR Homepage</a></li>
+                <li><a href="https://www.hl7.org/" target="_blank" rel="noopener noreferrer">HL7 International Official Website</a></li>
+                <li><a href="https://www.hl7.org/implement/standards/index.cfm" target="_blank" rel="noopener noreferrer">HL7 Standards & Implementations</a></li>
+                <li><a href="https://www.hl7.org/fhir/" target="_blank" rel="noopener noreferrer">HL7 FHIR Homepage</a></li>
             </ul>
         </section>
     </main>
 
     <footer class="footer">
         <p>&copy; 2024 HL7Tools.io. All rights reserved.</p>
-        <p>Free and open source under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener" style="color:#17a2b8;">MIT License</a>.</p>
+        <p>Free and open source under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener noreferrer" style="color:#17a2b8;">MIT License</a>.</p>
     </footer>
 
     <script defer src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- Add `rel="noopener noreferrer"` to all external links for safer new-tab navigation
- Update HL7 International Official Website link to use `https://www.hl7.org/`

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1519ce0833297d2b51827b41282