### PR TITLE
chore: remove obsolete meta comment

### DIFF
--- a/hl7-message-analyzer.html
+++ b/hl7-message-analyzer.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HL7 Message Analyzer – Free Browser Tool | HL7 Tools</title>
     <meta name="description" content="Free browser-based HL7 v2 message analyzer. Parse, visualize, and debug HL7 messages with color-coded segments, search, and ASCII view—runs locally in your browser." />
-    <!-- removed obsolete meta keywords -->
     <meta name="author" content="HL7 Tools" />
     <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://hl7tools.io/hl7-message-analyzer.html" />


### PR DESCRIPTION
## Summary
- remove leftover comment about obsolete meta keywords

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d0c719248332b9d91f4eba5d128d