### PR TITLE
Clarify unimplemented localization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Simply open `hl7-message-analyzer.html` in your browser. No server required.
 
 ## Localization
 
-Select your preferred language using the **Language** menu in the interface. Translations live in the `locales/` folder. To add a new language, copy an existing file, translate the strings, and submit a pull request.
+Translation support is not yet implemented.
 
 ## Roadmap
 
-Current milestones focus on a command-line interface, community-driven localization, and export options. See [ROADMAP.md](ROADMAP.md) for the full roadmap.
+Current milestones focus on a command-line interface and export options. Localization remains a future milestone that requires further research. See [ROADMAP.md](ROADMAP.md) for the full roadmap.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- note that localization/translation support hasn't been implemented yet
- highlight that localization is still a future milestone requiring research

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c43786680c8332bcc6b9e7b04bb01f