### PR TITLE
Update footer copyright year

### DIFF
--- a/hl7-message-analyzer.html
+++ b/hl7-message-analyzer.html
@@ -283,7 +283,7 @@
     </main>
 
     <footer class="footer">
-        <p>&copy; 2024 HL7Tools.io. All rights reserved.</p>
+        <p>&copy; 2025 HL7Tools.io. All rights reserved.</p>
         <p>Free and open source under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener noreferrer" style="color:#17a2b8;">MIT License</a>.</p>
     </footer>
 


### PR DESCRIPTION
## Summary
- update the footer copyright notice to reference 2025

## Testing
- manually verified the footer year in a browser

------
https://chatgpt.com/codex/tasks/task_e_68cd683dd2d88332b17a787df3001536